### PR TITLE
Fix：错误的使用 riderScoreSetHandler 来判断subscribeMsgPopup和subscribeMsgChange

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -58,8 +58,8 @@ type Server struct {
 	deliveryOrderReaddHandler         func(*DeliveryOrderReaddResult) *DeliveryOrderReaddReturn
 	preAuthCodeGetHandler             func(*PreAuthCodeGetResult) *PreAuthCodeGetReturn
 	riderScoreSetHandler              func(*RiderScoreSetResult) *RiderScoreSetReturn
-	subscribeMsgPopup                 func(*SubscribeMsgPopupEvent)
-	subscribeMsgChange                func(*SubscribeMsgChangeEvent)
+	subscribeMsgPopupHandler          func(*SubscribeMsgPopupEvent)
+	subscribeMsgChangeHandler         func(*SubscribeMsgChangeEvent)
 }
 
 // OnCustomerServiceTextMessage add handler to handle customer text service message.
@@ -190,12 +190,12 @@ func (srv *Server) OnRiderScoreSet(fn func(*RiderScoreSetResult) *RiderScoreSetR
 
 // 当用户触发订阅消息弹框后
 func (srv *Server) OnSubscribeMsgPopup(fn func(*SubscribeMsgPopupEvent)) {
-	srv.subscribeMsgPopup = fn
+	srv.subscribeMsgPopupHandler = fn
 }
 
 // 当用户通过设置界面改变订阅消息事件内容
 func (srv *Server) OnSubscribeMsgChange(fn func(*SubscribeMsgChangeEvent)) {
-	srv.subscribeMsgChange = fn
+	srv.subscribeMsgChangeHandler = fn
 }
 
 // NewServer 返回经过初始化的Server
@@ -534,8 +534,8 @@ func (srv *Server) handleRequest(w http.ResponseWriter, r *http.Request, isEncrp
 			if err := unmarshal(raw, ctp, msg); err != nil {
 				return nil, err
 			}
-			if srv.riderScoreSetHandler != nil {
-				srv.subscribeMsgPopup(msg)
+			if srv.subscribeMsgPopupHandler != nil {
+				srv.subscribeMsgPopupHandler(msg)
 			}
 
 		case EventSubscribeMsgChange:
@@ -543,8 +543,8 @@ func (srv *Server) handleRequest(w http.ResponseWriter, r *http.Request, isEncrp
 			if err := unmarshal(raw, ctp, msg); err != nil {
 				return nil, err
 			}
-			if srv.riderScoreSetHandler != nil {
-				srv.subscribeMsgChange(msg)
+			if srv.subscribeMsgChangeHandler != nil {
+				srv.subscribeMsgChangeHandler(msg)
 			}
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -520,14 +520,6 @@ func (srv *Server) handleRequest(w http.ResponseWriter, r *http.Request, isEncrp
 			if srv.addNearbyPoiAuditHandler != nil {
 				srv.addNearbyPoiAuditHandler(msg)
 			}
-		default:
-			msg := make(map[string]interface{})
-			if err := unmarshal(raw, ctp, msg); err != nil {
-				return nil, err
-			}
-			if srv.handler != nil {
-				return srv.handler(msg), nil
-			}
 
 		case EventSubscribeMsgPopup:
 			msg := new(SubscribeMsgPopupEvent)
@@ -545,6 +537,15 @@ func (srv *Server) handleRequest(w http.ResponseWriter, r *http.Request, isEncrp
 			}
 			if srv.subscribeMsgChangeHandler != nil {
 				srv.subscribeMsgChangeHandler(msg)
+			}
+
+		default:
+			msg := make(map[string]interface{})
+			if err := unmarshal(raw, ctp, msg); err != nil {
+				return nil, err
+			}
+			if srv.handler != nil {
+				return srv.handler(msg), nil
 			}
 		}
 


### PR DESCRIPTION
调用subscribeMsgPopup和subscribeMsgChange的时候错误的判断了riderScoreSetHandler

https://github.com/medivhzhan/miniapp/blob/bf105c44b8f3afe4c528373376915cc1b09a8072/server/server.go#L537-L539

https://github.com/medivhzhan/miniapp/blob/bf105c44b8f3afe4c528373376915cc1b09a8072/server/server.go#L546-L548